### PR TITLE
[ITHELP-2480] Added CHECK_FILESIZE_ONLY key to control download recipe

### DIFF
--- a/TeamViewerHost/TeamViewerHost.pkg.recipe
+++ b/TeamViewerHost/TeamViewerHost.pkg.recipe
@@ -12,6 +12,12 @@
 	<dict>
 		<key>NAME</key>
 		<string>TeamViewerHost</string>
+        <key>Comment</key>
+        <string>The download recipe is not handling etag and last_modified correctly so
+        we need to change the way we control when we need to do a new download.
+        </string>
+        <key>CHECK_FILESIZE_ONLY</key>
+        <string>true</string>
 	</dict>
 	<key>Process</key>
 	<array>


### PR DESCRIPTION
The download recipe is not handling etag and last_modified correctly so we need to change the way we control when we need to do a new download.